### PR TITLE
Support to run the API with Docker, and update docs on README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.6.15-slim
+RUN mkdir /app
+ADD riffapi-local.py /app
+WORKDIR /app
+RUN pip install Flask
+EXPOSE 5144/tcp
+CMD ["python3", "riffapi-local.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.15-slim
+FROM python:3.11.3-slim
 RUN mkdir /app
 ADD riffapi-local.py /app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Patch `ParseOctane.dll` to use RiffApi Local changing "https://parseapi.back4app
 
 You have two options:
 
-1. Use [Docker](https://www.docker.com/products/docker-desktop/) (recommended).
-
-   Open a command prompt on this directory and run `docker compose up --build`
-
-2. Install [Python 3.6+](https://www.python.org/downloads/release/python-368/) and [Flask](https://pypi.org/project/Flask/).
+1. Install [Python 3.6+](https://www.python.org/downloads/) and [Flask](https://pypi.org/project/Flask/) (recommended).
 
    Run `riffapi-local.py`.
+
+2. Use [Docker](https://www.docker.com/products/docker-desktop/).
+
+   Open a command prompt on this directory and run `docker compose up --build`
 
 **Important**: keep open the command prompt until you exit the game.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,33 @@ This project is a basic local server for the [Riff Racer](https://store.steampow
 - Python 3.6+
 - Flask
 
+(Or Docker)
+
 ## Usage
 
-Run `sed -i "s/https:\/\/parseapi.back4app.com/http:\/\/127.000000000.0.1:5144/g" ParseOctane.dll` in your game directory to patch the Parse API DLL to use RiffApi Local instead. Then, run `riffapi-local.py` and launch the game.
+### Patching ParseOctane.dll
+
+Patch `ParseOctane.dll` to use RiffApi Local changing "https://parseapi.back4app.com" by "http://127.000000000.0.1:5144".
+
+1. Open Steam and go to your game library
+2. Right click on "Riff Racer" on the game list
+3. Press on "manage" > "browse local files", it will open the folder where the game files are located.
+4. Open a command prompt, `shift` + `right-click` and "Open PowerShell window here
+5. Run `sed -i "s/https:\/\/parseapi.back4app.com/http:\/\/127.000000000.0.1:5144/g" ParseOctane.dll` or open "ParseOctane.dll" with a text editor and replace all the occurrences of "https://parseapi.back4app.com" by "http://127.000000000.0.1:5144".
+
+### Running the API
+
+You have two options:
+
+1. Use [Docker](https://www.docker.com/products/docker-desktop/) (recommended).
+
+   Open a command prompt on this directory and run `docker compose up --build`
+
+2. Install [Python 3.6+](https://www.python.org/downloads/release/python-368/) and [Flask](https://pypi.org/project/Flask/).
+
+   Run `riffapi-local.py`.
+
+**Important**: keep open the command prompt until you exit the game.
 
 ## riffapi.hobune.stream
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  app:
+    build: .
+    ports:
+      - "5144:5144"
+    command: python3 riffapi-local.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
-version: '3'
+version: "3"
 
 services:
   app:
     build: .
     ports:
       - "5144:5144"
-    command: python3 riffapi-local.py


### PR DESCRIPTION
Add support to run the web API using Docker and update the documentation with more detailed steps.

Documentation explains how to run it via docker or by installing python and Flask.